### PR TITLE
refactor: replace template strings with concatenation in Rhai files

### DIFF
--- a/docs/example/protocol/protocol-client/main.rhai
+++ b/docs/example/protocol/protocol-client/main.rhai
@@ -31,7 +31,7 @@ const VARIANTS = #{
 };
 
 const VARIANT = VARIANTS[node_env().node_variant];
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const BABEL_VERSION = "0.1.0";
 
 // Determine extra args based on variant

--- a/protocols/axelar/axelar-axelard/babel.yaml
+++ b/protocols/axelar/axelar-axelard/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.3
-container_uri: docker://ghcr.io/blockjoy/axelar-axelard-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/axelar-axelard-protocol:v20250202.1
 sku_code: AXELAR-AXELARD
 org_id: null
 description: Axelar Axelard

--- a/protocols/axelar/axelar-axelard/main.rhai
+++ b/protocols/axelar/axelar-axelard/main.rhai
@@ -10,7 +10,7 @@ const GRPC_WEB_PORT = 9091;
 const GRPC_PORT = 9090;
 const METRICS_PORT = 26660;
 const METRICS_PATH = "/metrics";
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 
 
 let AUX_CONFIG = aux::base_config(global::AXELAR_DIR, global::METRICS_PORT, global::P2P_PORT, global::RPC_PORT, global::REST_PORT, global::GRPC_WEB_PORT, global::GRPC_PORT, global::CADDY_DIR, global::METRICS_PATH);

--- a/protocols/base/base-op-reth/babel.yaml
+++ b/protocols/base/base-op-reth/babel.yaml
@@ -1,5 +1,5 @@
 version: 1.1.1
-container_uri: docker://ghcr.io/blockjoy/base-op-reth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/base-op-reth-protocol:v20250202.1
 sku_code: BASE-OP-RETH
 org_id: null
 description: Base OP Reth node1

--- a/protocols/base/base-op-reth/main.rhai
+++ b/protocols/base/base-op-reth/main.rhai
@@ -32,7 +32,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const HOME = node_env().protocol_data_path + "/base";
 const NET = VARIANTS[node_env().node_variant].net;
 const CHAIN = VARIANTS[node_env().node_variant].chain;

--- a/protocols/blast/blast-geth/babel.yaml
+++ b/protocols/blast/blast-geth/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.4
-container_uri: docker://ghcr.io/blockjoy/blast-geth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/blast-geth-protocol:v20250202.1
 sku_code: BLAST-GETH
 org_id: null
 description: Blast Geth

--- a/protocols/blast/blast-geth/main.rhai
+++ b/protocols/blast/blast-geth/main.rhai
@@ -12,7 +12,7 @@ const METRICS_PATH = "/debug/metrics/prometheus";
 
 const L1_RPCKIND = "standard";
 
-const GETH_API = `http://127.0.0.1:${global::RPC_PORT}`;
+const GETH_API = "http://127.0.0.1:" + global::RPC_PORT;
 const BLAST_API = `http://127.0.0.1:${global::OP_NODE_RPC_PORT}`;
 const BLAST_DIR = node_env().protocol_data_path + "/blast";
 

--- a/protocols/bsc/bsc-erigon/babel.yaml
+++ b/protocols/bsc/bsc-erigon/babel.yaml
@@ -1,5 +1,5 @@
 version: 1.12.2
-container_uri: docker://ghcr.io/blockjoy/bsc-erigon-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/bsc-erigon-protocol:v20250202.1
 sku_code: BSC-ERG
 org_id: null
 description: Binance Smart Chain

--- a/protocols/bsc/bsc-erigon/main.rhai
+++ b/protocols/bsc/bsc-erigon/main.rhai
@@ -22,7 +22,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const HOME = node_env().protocol_data_path + "/bsc";
 const NET = VARIANTS[node_env().node_variant].net;
 const CHAIN_ID = VARIANTS[node_env().node_variant].chain_id;

--- a/protocols/celo/celo-geth/babel.yaml
+++ b/protocols/celo/celo-geth/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.3
-container_uri: docker://ghcr.io/blockjoy/celo-geth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/celo-geth-protocol:v20250202.1
 sku_code: CELO-GETH
 org_id: null
 description: Celo Geth

--- a/protocols/celo/celo-geth/main.rhai
+++ b/protocols/celo/celo-geth/main.rhai
@@ -8,7 +8,7 @@ const P2P_PORT = 30303;
 const METRICS_PORT = 7770;
 const METRICS_PATH = "/debug/metrics/prometheus";
 
-const CELO_API = `http://127.0.0.1:${global::RPC_PORT}`;
+const CELO_API = "http://127.0.0.1:" + global::RPC_PORT;
 const CELO_DIR = node_env().protocol_data_path + "/celo";
 
 let AUX_CONFIG = aux::base_config(global::METRICS_PORT, global::RPC_PORT, global::WS_PORT, global::CADDY_DIR, global::METRICS_PATH);

--- a/protocols/ethereum/ethereum-erigon/babel.yaml
+++ b/protocols/ethereum/ethereum-erigon/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.0.5
-container_uri: docker://ghcr.io/blockjoy/ethereum-erigon-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/ethereum-erigon-protocol:v20250202.1
 sku_code: ETH-ERG
 org_id: null
 description: Ethereum Erigon node

--- a/protocols/ethereum/ethereum-erigon/main.rhai
+++ b/protocols/ethereum/ethereum-erigon/main.rhai
@@ -40,7 +40,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 
 const HOME = node_env().protocol_data_path + "/erigon";
 

--- a/protocols/ethereum/ethereum-reth/babel.yaml
+++ b/protocols/ethereum/ethereum-reth/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.0.13
-container_uri: docker://ghcr.io/blockjoy/ethereum-reth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/ethereum-reth-protocol:v20250202.1
 sku_code: ETH-RETH
 org_id: null
 description: Ethereum Reth node 2

--- a/protocols/ethereum/ethereum-reth/main.rhai
+++ b/protocols/ethereum/ethereum-reth/main.rhai
@@ -32,7 +32,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const HOME = node_env().protocol_data_path + "/reth";
 const LIGHTHOUSE_DIR = node_env().protocol_data_path + "/lighthouse";
 const NET = VARIANTS[node_env().node_variant].net;

--- a/protocols/fantom/fantom-opera/babel.yaml
+++ b/protocols/fantom/fantom-opera/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.7
-container_uri: docker://ghcr.io/blockjoy/fantom-opera-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/fantom-opera-protocol:v20250202.1
 sku_code: FANTOM-OPERA
 org_id: null
 description: Fantom Opera

--- a/protocols/fantom/fantom-opera/main.rhai
+++ b/protocols/fantom/fantom-opera/main.rhai
@@ -8,7 +8,7 @@ const P2P_PORT = 5050;
 const METRICS_PORT = 6060;
 const METRICS_PATH = "/debug/metrics/prometheus";
 
-const FANTOM_API = `http://127.0.0.1:${global::RPC_PORT}`;
+const FANTOM_API = "http://127.0.0.1:" + global::RPC_PORT;
 const FANTOM_DIR = node_env().protocol_data_path + "/fantom";
 
 let AUX_CONFIG = aux::base_config(global::METRICS_PORT, global::RPC_PORT, global::WS_PORT, global::CADDY_DIR, global::METRICS_PATH);

--- a/protocols/gnosis/gnosis-erigon/babel.yaml
+++ b/protocols/gnosis/gnosis-erigon/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.0.10
-container_uri: docker://ghcr.io/blockjoy/gnosis-erigon-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/gnosis-erigon-protocol:v20250202.1
 sku_code: GNO-ERG
 org_id: null
 description: Gnosis Chain Erigon node

--- a/protocols/gnosis/gnosis-erigon/main.rhai
+++ b/protocols/gnosis/gnosis-erigon/main.rhai
@@ -25,7 +25,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const HOME = node_env().protocol_data_path + "/erigon";
 const NET = "gnosis";
 const CHECKPOINT_URL = VARIANTS[node_env().node_variant].url;

--- a/protocols/optimism/optimism-geth/babel.yaml
+++ b/protocols/optimism/optimism-geth/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.2
-container_uri: docker://ghcr.io/blockjoy/optimism-geth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/optimism-geth-protocol:v20250202.1
 sku_code: OP-GETH
 org_id: null
 description: Optimism Geth

--- a/protocols/optimism/optimism-geth/main.rhai
+++ b/protocols/optimism/optimism-geth/main.rhai
@@ -11,7 +11,7 @@ const L1_URL = "https://eth-l1.blkjy.io";
 const L1_BEACON_URL = "https://lighthouse.blkjy.io";
 const L1_RPCKIND = "standard";
 
-const GETH_API = `http://127.0.0.1:${global::RPC_PORT}`;
+const GETH_API = "http://127.0.0.1:" + global::RPC_PORT;
 const OPTIMISM_API = "http://127.0.0.1:8547";
 const DATADIR = node_env().protocol_data_path;
 const OP_DIR = node_env().protocol_data_path + "/optimism";

--- a/protocols/optimism/optimism-reth/babel.yaml
+++ b/protocols/optimism/optimism-reth/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.1
-container_uri: docker://ghcr.io/blockjoy/optimism-reth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/optimism-reth-protocol:v20250202.1
 sku_code: OP-RETH
 org_id: null
 description: Optimism Reth

--- a/protocols/optimism/optimism-reth/main.rhai
+++ b/protocols/optimism/optimism-reth/main.rhai
@@ -11,7 +11,7 @@ const L1_URL = "https://eth-l1.blkjy.io";
 const L1_BEACON_URL = "https://lighthouse.blkjy.io";
 const L1_RPCKIND = "standard";
 
-const RETH_API = `http://127.0.0.1:${global::RPC_PORT}`;
+const RETH_API = "http://127.0.0.1:" + global::RPC_PORT;
 const OPTIMISM_API = "http://127.0.0.1:7000";
 
 let AUX_CONFIG = aux::base_config(global::METRICS_PORT, global::RPC_PORT, global::WS_PORT, global::CADDY_DIR, global::METRICS_PATH);
@@ -36,7 +36,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const HOME = node_env().protocol_data_path + "/op-reth";
 const DATADIR = node_env().protocol_data_path;
 const OP_DIR = node_env().protocol_data_path + "/optimism";

--- a/protocols/polygon/polygon-bor/babel.yaml
+++ b/protocols/polygon/polygon-bor/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.6
-container_uri: docker://ghcr.io/blockjoy/polygon-bor-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/polygon-bor-protocol:v20250202.1
 sku_code: POLY-BOR
 org_id: null
 description: Polygon

--- a/protocols/polygon/polygon-bor/main.rhai
+++ b/protocols/polygon/polygon-bor/main.rhai
@@ -26,7 +26,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const P2P_SEEDS = VARIANTS[node_env().node_variant].p2p_seeds;
 const BOOTNODES = VARIANTS[node_env().node_variant].bootnodes;
 const NETWORK = VARIANTS[node_env().node_variant].network;

--- a/protocols/polygon/polygon-erigon/babel.yaml
+++ b/protocols/polygon/polygon-erigon/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.1.3
-container_uri: docker://ghcr.io/blockjoy/polygon-erigon-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/polygon-erigon-protocol:v20250202.1
 sku_code: POLY-ERIGON
 org_id: null
 description: Polygon

--- a/protocols/polygon/polygon-erigon/main.rhai
+++ b/protocols/polygon/polygon-erigon/main.rhai
@@ -25,7 +25,7 @@ const VARIANTS = #{
     },
 };
 
-const API_HOST = `http://127.0.0.1:${global::RPC_PORT}`;
+const API_HOST = "http://127.0.0.1:" + global::RPC_PORT;
 const P2P_SEEDS = VARIANTS[node_env().node_variant].p2p_seeds;
 const BOOTNODES = VARIANTS[node_env().node_variant].bootnodes;
 const NETWORK = VARIANTS[node_env().node_variant].network;

--- a/protocols/shape/shape-geth/babel.yaml
+++ b/protocols/shape/shape-geth/babel.yaml
@@ -1,5 +1,5 @@
 version: 0.0.5
-container_uri: docker://ghcr.io/blockjoy/shape-geth-protocol:v20250201.3
+container_uri: docker://ghcr.io/blockjoy/shape-geth-protocol:v20250202.1
 sku_code: SHAPE-GETH
 org_id: null
 description: Shape Geth

--- a/protocols/shape/shape-geth/main.rhai
+++ b/protocols/shape/shape-geth/main.rhai
@@ -11,7 +11,7 @@ const METRICS_PATH = "/debug/metrics/prometheus";
 
 const L1_RPCKIND = "standard";
 
-const GETH_API = `http://127.0.0.1:${global::RPC_PORT}`;
+const GETH_API = "http://127.0.0.1:" + global::RPC_PORT;
 const SHAPE_API = "http://127.0.0.1:8547";
 const SHAPE_DIR = node_env().protocol_data_path + "/shape";
 


### PR DESCRIPTION
Replace template string literals with string concatenation for RPC URLs across all Rhai files. This changes patterns like:
  `http://127.0.0.1:${global::RPC_PORT}`
to:
  "http://127.0.0.1:" + global::RPC_PORT

This change improves consistency in string handling across the codebase.